### PR TITLE
Improve unknown attribute classification and add datetime platform

### DIFF
--- a/custom_components/vitotrol/attributes.py
+++ b/custom_components/vitotrol/attributes.py
@@ -89,9 +89,10 @@ _CATEGORIES: dict[str, dict] = {
     # -- Number categories ---------------------------------------------------
     "num_temp":   dict(platform="number", unit=UnitOfTemperature.CELSIUS, device_class=NumberDeviceClass.TEMPERATURE, entity_category=EntityCategory.CONFIG),
     "num":        dict(platform="number", entity_category=EntityCategory.CONFIG),
-    # -- Switch / select / none ----------------------------------------------
+    # -- Switch / select / datetime / none -----------------------------------
     "switch":     dict(platform="switch"),
     "select":     dict(platform="select"),
+    "date":       dict(platform="datetime"),
     "none":       dict(),
 }
 
@@ -196,9 +197,9 @@ _TABLE: list[tuple[int, str, bool, str]] = [
     # ---- No standalone entity (used by climate / not parseable) -------------
     (92,    "Operating mode",                    False,  "select"),  # also used by climate
     (82,    "Room temperature setpoint",         False,  "none"),  # climate RW
-    (5385,  "Device date/time",                  False,  "none"),
-    (306,   "Holiday start date",                False,  "none"),
-    (309,   "Holiday end date",                  False,  "none"),
+    (5385,  "Device date/time",                  False,  "date"),
+    (306,   "Holiday start date",                False,  "date"),
+    (309,   "Holiday end date",                  False,  "date"),
     (7191,  "Heating schedule",                  False,  "none"),
     (7192,  "Hot water schedule",                False,  "none"),
     (7193,  "Circulation schedule",              False,  "none"),

--- a/custom_components/vitotrol/binary_sensor.py
+++ b/custom_components/vitotrol/binary_sensor.py
@@ -10,7 +10,7 @@ from . import VitotrolConfigEntry
 from .api import AttributeTypeInfo, VitotrolDevice
 from .attributes import ATTRIBUTE_REGISTRY, AttrMeta
 from .coordinator import VitotrolCoordinator
-from .entity import VitotrolEntity
+from .entity import VitotrolEntity, infer_unknown_metadata
 
 
 async def async_setup_entry(
@@ -28,9 +28,16 @@ async def async_setup_entry(
 
         for attr_id, info in catalog.items():
             meta = ATTRIBUTE_REGISTRY.get(attr_id)
-            if meta is None or meta.platform != "binary_sensor":
-                continue
-            entities.append(VitotrolBinarySensor(coordinator, device, info, meta))
+
+            if meta is not None:
+                if meta.platform != "binary_sensor":
+                    continue
+                entities.append(VitotrolBinarySensor(coordinator, device, info, meta))
+            else:
+                inferred = infer_unknown_metadata(info)
+                if inferred.platform != "binary_sensor":
+                    continue
+                entities.append(VitotrolBinarySensor(coordinator, device, info, meta=None))
 
     async_add_entities(entities)
 
@@ -43,15 +50,28 @@ class VitotrolBinarySensor(VitotrolEntity, BinarySensorEntity):
         coordinator: VitotrolCoordinator,
         device: VitotrolDevice,
         info: AttributeTypeInfo,
-        meta: AttrMeta,
+        meta: AttrMeta | None,
     ) -> None:
-        key = meta.name.lower().replace(" ", "_")
+        key = meta.name.lower().replace(" ", "_") if meta else f"attr_{info.attr_id}"
         super().__init__(coordinator, device, key)
         self._vitotrol_attr_id = info.attr_id
-        self._on_values = meta.on_values or ("1",)
-        self._attr_name = meta.name
-        self._attr_entity_registry_enabled_default = meta.enabled_by_default
-        self._attr_device_class = meta.device_class
+
+        if meta is not None:
+            self._on_values = meta.on_values or ("1",)
+            self._attr_name = meta.name
+            self._attr_entity_registry_enabled_default = meta.enabled_by_default
+            self._attr_device_class = meta.device_class
+        else:
+            inferred = infer_unknown_metadata(info)
+            self._attr_name = inferred.display_name
+            self._attr_entity_registry_enabled_default = False
+            # Find the raw key whose label is "Ein" (on)
+            on_keys = tuple(
+                str(k)
+                for k, v in (info.enum_values or {}).items()
+                if v.lower() == "ein"
+            )
+            self._on_values = on_keys if on_keys else ("1",)
 
     @property
     def available(self) -> bool:

--- a/custom_components/vitotrol/const.py
+++ b/custom_components/vitotrol/const.py
@@ -9,6 +9,7 @@ DOMAIN = "vitotrol"
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
+    Platform.DATETIME,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,

--- a/custom_components/vitotrol/datetime.py
+++ b/custom_components/vitotrol/datetime.py
@@ -1,8 +1,11 @@
-"""Select platform for the Viessmann Vitotrol integration."""
+"""Datetime platform for the Viessmann Vitotrol integration."""
 
 from __future__ import annotations
 
-from homeassistant.components.select import SelectEntity
+import logging
+from datetime import datetime, timezone
+
+from homeassistant.components.datetime import DateTimeEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -12,16 +15,37 @@ from .attributes import ATTRIBUTE_REGISTRY, AttrMeta
 from .coordinator import VitotrolCoordinator
 from .entity import VitotrolEntity, infer_unknown_metadata
 
+_LOGGER = logging.getLogger(__name__)
+
+# API date/time string formats, tried in order
+_PARSE_FORMATS = (
+    "%Y-%m-%d %H:%M:%S",
+    "%d.%m.%Y",
+)
+_WRITE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def _parse_api_datetime(raw: str) -> datetime | None:
+    """Parse an API date string into an aware UTC datetime."""
+    for fmt in _PARSE_FORMATS:
+        try:
+            naive = datetime.strptime(raw.strip(), fmt)
+            return naive.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    _LOGGER.debug("Cannot parse datetime string %r", raw)
+    return None
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: VitotrolConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Vitotrol select entities for writable enum attributes."""
+    """Set up Vitotrol datetime entities."""
     runtime = entry.runtime_data
     coordinator = runtime.coordinator
-    entities: list[SelectEntity] = []
+    entities: list[DateTimeEntity] = []
 
     for device in coordinator.devices:
         catalog = coordinator.get_attribute_catalog(device.device_id)
@@ -30,20 +54,20 @@ async def async_setup_entry(
             meta = ATTRIBUTE_REGISTRY.get(attr_id)
 
             if meta is not None:
-                if meta.platform != "select":
+                if meta.platform != "datetime":
                     continue
-                entities.append(VitotrolSelect(coordinator, device, info, meta))
+                entities.append(VitotrolDateTime(coordinator, device, info, meta))
             else:
                 inferred = infer_unknown_metadata(info)
-                if inferred.platform != "select":
+                if inferred.platform != "datetime":
                     continue
-                entities.append(VitotrolSelect(coordinator, device, info, meta=None))
+                entities.append(VitotrolDateTime(coordinator, device, info, meta=None))
 
     async_add_entities(entities)
 
 
-class VitotrolSelect(VitotrolEntity, SelectEntity):
-    """Select entity for a writable enum attribute."""
+class VitotrolDateTime(VitotrolEntity, DateTimeEntity):
+    """Datetime entity for a Vitotrol date attribute."""
 
     def __init__(
         self,
@@ -56,27 +80,13 @@ class VitotrolSelect(VitotrolEntity, SelectEntity):
         super().__init__(coordinator, device, key)
         self._vitotrol_attr_id = info.attr_id
 
-        if meta is not None and meta.enum_map is not None:
+        if meta is not None:
             self._attr_name = meta.name
             self._attr_entity_registry_enabled_default = meta.enabled_by_default
-            self._value_to_label = meta.enum_map
         else:
-            # Fallback: use German labels from GetTypeInfo
-            if meta is None:
-                inferred = infer_unknown_metadata(info)
-                self._attr_name = inferred.display_name
-                self._attr_entity_registry_enabled_default = False
-            else:
-                self._attr_name = meta.name
-                self._attr_entity_registry_enabled_default = meta.enabled_by_default
-            self._value_to_label = (
-                {str(k): v for k, v in info.enum_values.items()}
-                if info.enum_values
-                else {}
-            )
-
-        self._label_to_value = {v: k for k, v in self._value_to_label.items()}
-        self._attr_options = list(self._value_to_label.values())
+            inferred = infer_unknown_metadata(info)
+            self._attr_name = inferred.display_name
+            self._attr_entity_registry_enabled_default = False
 
     @property
     def available(self) -> bool:
@@ -84,21 +94,18 @@ class VitotrolSelect(VitotrolEntity, SelectEntity):
         return super().available and self._vitotrol_attr_id in self._device_data
 
     @property
-    def current_option(self) -> str | None:
-        """Return the currently selected option."""
+    def native_value(self) -> datetime | None:
+        """Return the current datetime value."""
         raw = self._get_attr_value(self._vitotrol_attr_id)
         if raw is None:
             return None
-        return self._value_to_label.get(raw)
+        return _parse_api_datetime(raw)
 
-    async def async_select_option(self, option: str) -> None:
-        """Set a new option."""
-        raw_value = self._label_to_value.get(option)
-        if raw_value is None:
-            return
-
+    async def async_set_value(self, value: datetime) -> None:
+        """Set a new datetime value."""
+        str_value = value.astimezone(timezone.utc).strftime(_WRITE_FORMAT)
         await self.coordinator.async_write(
-            self._device, self._vitotrol_attr_id, raw_value
+            self._device, self._vitotrol_attr_id, str_value
         )
-        self._update_coordinator_data(self._vitotrol_attr_id, raw_value)
+        self._update_coordinator_data(self._vitotrol_attr_id, str_value)
         self.async_write_ha_state()

--- a/custom_components/vitotrol/entity.py
+++ b/custom_components/vitotrol/entity.py
@@ -3,15 +3,118 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import (
+    UnitOfEnergy,
+    UnitOfMass,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+    UnitOfVolume,
+    PERCENTAGE,
+)
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .api import VitotrolDevice
+from .api import AttributeTypeInfo, VitotrolDevice
 from .const import DOMAIN
 from .coordinator import VitotrolCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class InferredMeta:
+    """Inferred metadata for an unknown Vitotrol attribute."""
+
+    platform: str | None
+    display_name: str
+    device_class: str | None = None
+    state_class: str | None = None
+    unit: str | None = None
+    suggested_precision: int | None = None
+
+
+def _is_binary_enum(info: AttributeTypeInfo) -> bool:
+    """Return True if enum values look like a simple on/off pair."""
+    if info.enum_values is None:
+        return False
+    labels = {str(v).lower() for v in info.enum_values.values()}
+    return labels <= {"aus", "ein"}
+
+
+def _group_prefix(group: str) -> str:
+    """Extract the subsystem suffix after '~' from a group string."""
+    if "~" in group:
+        return group.split("~")[-1]
+    return ""
+
+
+def _infer_numeric_meta(name: str) -> tuple[str | None, str | None, str | None, int | None]:
+    """Return (device_class, unit, state_class, suggested_precision) for a numeric attr name."""
+    n = name.lower()
+    if n.startswith("temp_") or n.startswith("info_temp_"):
+        return SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, SensorStateClass.MEASUREMENT, 1
+    if n.startswith("anzahl_brennerstunden"):
+        return SensorDeviceClass.DURATION, UnitOfTime.HOURS, SensorStateClass.TOTAL_INCREASING, None
+    if n.startswith("anzahl_brennerstart"):
+        return None, None, SensorStateClass.TOTAL_INCREASING, None
+    if n.startswith("info_brenner_modulation"):
+        return None, PERCENTAGE, SensorStateClass.MEASUREMENT, None
+    if n.startswith("info_historie_eee_"):
+        return SensorDeviceClass.ENERGY, UnitOfEnergy.KILO_WATT_HOUR, SensorStateClass.TOTAL, None
+    if n.startswith("info_historie_co2_"):
+        return SensorDeviceClass.WEIGHT, UnitOfMass.KILOGRAMS, SensorStateClass.TOTAL, None
+    if "leistung" in n and n.startswith("info_"):
+        return SensorDeviceClass.POWER, UnitOfPower.WATT, SensorStateClass.MEASUREMENT, None
+    if "verbrauch" in n and n.startswith("info_"):
+        return SensorDeviceClass.GAS, UnitOfVolume.CUBIC_METERS, SensorStateClass.TOTAL_INCREASING, None
+    if "einsparung" in n and n.startswith("info_"):
+        return SensorDeviceClass.WEIGHT, UnitOfMass.KILOGRAMS, SensorStateClass.TOTAL_INCREASING, None
+    if n.startswith("info_energie_"):
+        return SensorDeviceClass.ENERGY, UnitOfEnergy.KILO_WATT_HOUR, SensorStateClass.TOTAL_INCREASING, None
+    if n.startswith("info_verhaeltnis_"):
+        return None, PERCENTAGE, SensorStateClass.MEASUREMENT, None
+    return None, None, SensorStateClass.MEASUREMENT, None
+
+
+def infer_unknown_metadata(info: AttributeTypeInfo) -> InferredMeta:
+    """Infer platform and HA metadata for an attribute not in the registry."""
+    prefix = _group_prefix(info.group)
+    display_name = f"{prefix}: {info.name}" if prefix else info.name
+
+    t = info.type
+
+    if t == "Date":
+        return InferredMeta(platform="datetime", display_name=display_name)
+
+    if t == "CircuitTime":
+        return InferredMeta(platform=None, display_name=display_name)
+
+    if t == "ENUM":
+        if _is_binary_enum(info) and not info.writable:
+            return InferredMeta(platform="binary_sensor", display_name=display_name)
+        if info.writable:
+            return InferredMeta(platform="select", display_name=display_name)
+        return InferredMeta(platform="sensor", display_name=display_name)
+
+    if t in ("Double", "Integer"):
+        if info.writable and info.enum_values is None:
+            return InferredMeta(platform="number", display_name=display_name)
+        device_class, unit, state_class, precision = _infer_numeric_meta(info.name)
+        return InferredMeta(
+            platform="sensor",
+            display_name=display_name,
+            device_class=device_class,
+            state_class=state_class,
+            unit=unit,
+            suggested_precision=precision,
+        )
+
+    # String and anything else
+    return InferredMeta(platform="sensor", display_name=display_name)
 
 
 class VitotrolEntity(CoordinatorEntity[VitotrolCoordinator]):

--- a/custom_components/vitotrol/number.py
+++ b/custom_components/vitotrol/number.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
-from homeassistant.const import UnitOfTemperature
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -13,7 +12,7 @@ from . import VitotrolConfigEntry
 from .api import AttributeTypeInfo, VitotrolDevice
 from .attributes import ATTRIBUTE_REGISTRY, AttrMeta
 from .coordinator import VitotrolCoordinator
-from .entity import VitotrolEntity
+from .entity import VitotrolEntity, infer_unknown_metadata
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,10 +38,8 @@ async def async_setup_entry(
                     continue
                 entities.append(VitotrolNumber(coordinator, device, info, meta))
             else:
-                # Unknown attr: auto-route RW numeric non-enum to number
-                if not info.writable or not info.readable:
-                    continue
-                if info.enum_values is not None:
+                inferred = infer_unknown_metadata(info)
+                if inferred.platform != "number":
                     continue
                 entities.append(VitotrolNumber(coordinator, device, info, meta=None))
 
@@ -73,13 +70,9 @@ class VitotrolNumber(VitotrolEntity, NumberEntity):
             self._attr_device_class = meta.device_class
             self._attr_entity_category = meta.entity_category
         else:
-            self._attr_name = info.name
+            inferred = infer_unknown_metadata(info)
+            self._attr_name = inferred.display_name
             self._attr_entity_registry_enabled_default = False
-            if info.unit == "\u00b0C":
-                self._attr_device_class = NumberDeviceClass.TEMPERATURE
-                self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-            elif info.unit:
-                self._attr_native_unit_of_measurement = info.unit
 
         # Min/max from API metadata
         try:

--- a/custom_components/vitotrol/sensor.py
+++ b/custom_components/vitotrol/sensor.py
@@ -16,7 +16,7 @@ from . import VitotrolConfigEntry
 from .api import AttributeTypeInfo, VitotrolDevice
 from .attributes import ATTRIBUTE_REGISTRY, AttrMeta
 from .coordinator import VitotrolCoordinator
-from .entity import VitotrolEntity
+from .entity import VitotrolEntity, infer_unknown_metadata
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,8 +42,8 @@ async def async_setup_entry(
                     continue
                 entities.append(VitotrolSensor(coordinator, device, info, meta))
             else:
-                # Unknown attr: auto-route RO to sensor
-                if not info.readable or info.writable:
+                inferred = infer_unknown_metadata(info)
+                if inferred.platform != "sensor":
                     continue
                 entities.append(VitotrolSensor(coordinator, device, info, meta=None))
 
@@ -78,17 +78,19 @@ class VitotrolSensor(VitotrolEntity, SensorEntity):
                 self._attr_device_class = SensorDeviceClass.ENUM
                 self._attr_options = list(meta.enum_map.values())
         else:
-            # Unknown attribute — fallback to API metadata
-            self._attr_name = info.name
+            inferred = infer_unknown_metadata(info)
+            self._attr_name = inferred.display_name
             self._attr_entity_registry_enabled_default = False
             if info.enum_values is not None:
                 enum_map = {str(k): v for k, v in info.enum_values.items()}
                 self._enum_values = enum_map
                 self._attr_device_class = SensorDeviceClass.ENUM
                 self._attr_options = list(enum_map.values())
-            elif info.unit:
-                self._attr_native_unit_of_measurement = info.unit
-                self._attr_state_class = SensorStateClass.MEASUREMENT
+            else:
+                self._attr_device_class = inferred.device_class
+                self._attr_state_class = inferred.state_class
+                self._attr_native_unit_of_measurement = inferred.unit
+                self._attr_suggested_display_precision = inferred.suggested_precision
 
     @property
     def available(self) -> bool:

--- a/scripts/discover.py
+++ b/scripts/discover.py
@@ -5,10 +5,13 @@ Logs in, discovers devices, calls GetTypeInfo, and prints all available
 attributes with their metadata (unit, type, min/max, RW flags, enums).
 
 With --values, also fetches current cached values via GetData.
+With --raw-xml, dumps the raw GetTypeInfo XML for offline analysis.
+With --json, outputs structured JSON instead of a table.
 
 Usage:
     python scripts/discover.py --user YOUR_EMAIL --password YOUR_PASSWORD
     python scripts/discover.py --user YOUR_EMAIL --password YOUR_PASSWORD --values
+    python scripts/discover.py --user YOUR_EMAIL --password YOUR_PASSWORD --json > dump.json
 
 Or set environment variables:
     VITOTROL_USER=... VITOTROL_PASSWORD=... python scripts/discover.py --values
@@ -18,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import re
 import sys
@@ -152,12 +156,20 @@ async def get_data(
     return all_values
 
 
-async def run(username: str, password: str, *, fetch_values: bool = False) -> None:
+async def run(
+    username: str,
+    password: str,
+    *,
+    fetch_values: bool = False,
+    output_json: bool = False,
+    dump_raw_xml: bool = False,
+) -> None:
     cookies: dict[str, str] = {}
+    json_output: list[dict] = []
 
     async with aiohttp.ClientSession() as session:
         # Login
-        print("Logging in...")
+        print("Logging in...", file=sys.stderr)
         await soap_request(
             session,
             cookies,
@@ -173,10 +185,10 @@ async def run(username: str, password: str, *, fetch_values: bool = False) -> No
             ),
             store_cookies=True,
         )
-        print("Login OK\n")
+        print("Login OK\n", file=sys.stderr)
 
         # Discover devices
-        print("Discovering devices...")
+        print("Discovering devices...", file=sys.stderr)
         dev_root = await soap_request(session, cookies, "GetDevices", "<GetDevices />")
 
         devices = []
@@ -190,19 +202,20 @@ async def run(username: str, password: str, *, fetch_values: bool = False) -> No
                 devices.append((loc_id, loc_name, dev_id, dev_name, connected))
 
         if not devices:
-            print("No devices found!")
+            print("No devices found!", file=sys.stderr)
             return
 
         for loc_id, loc_name, dev_id, dev_name, connected in devices:
-            print(f"  Location: {loc_name} (ID={loc_id})")
-            print(f"  Device:   {dev_name} (ID={dev_id}, connected={connected})")
-            print()
+            print(f"  Location: {loc_name} (ID={loc_id})", file=sys.stderr)
+            print(f"  Device:   {dev_name} (ID={dev_id}, connected={connected})", file=sys.stderr)
+            print(file=sys.stderr)
 
         # GetTypeInfo for each device
         for loc_id, loc_name, dev_id, dev_name, _ in devices:
-            print(f"{'='*80}")
-            print(f"GetTypeInfo for {dev_name} (device={dev_id}, location={loc_id})")
-            print(f"{'='*80}\n")
+            if not output_json:
+                print(f"{'='*80}")
+                print(f"GetTypeInfo for {dev_name} (device={dev_id}, location={loc_id})")
+                print(f"{'='*80}\n")
 
             type_root = await soap_request(
                 session,
@@ -215,6 +228,16 @@ async def run(username: str, password: str, *, fetch_values: bool = False) -> No
                     "</GetTypeInfo>"
                 ),
             )
+
+            # Optionally dump raw XML
+            if dump_raw_xml:
+                type_info_list = type_root.find(".//TypeInfoListe")
+                target = type_info_list if type_info_list is not None else type_root
+                raw_xml = ElementTree.tostring(target, encoding="unicode")
+                xml_file = f"typeinfo_{dev_id}.xml"
+                with open(xml_file, "w") as f:
+                    f.write(raw_xml)
+                print(f"  Raw XML dumped to {xml_file}", file=sys.stderr)
 
             # Collect all entries
             base_entries: dict[int, dict] = {}
@@ -236,6 +259,7 @@ async def run(username: str, password: str, *, fetch_values: bool = False) -> No
                     "id": attr_id,
                     "name": _find_text_opt(dp, "DatenpunktName") or "",
                     "type": _find_text_opt(dp, "DatenpunktTyp") or "",
+                    "type_value": _find_text_opt(dp, "DatenpunktTypWert") or "",
                     "min": _find_text_opt(dp, "MinimalWert") or "",
                     "max": _find_text_opt(dp, "MaximalWert") or "",
                     "unit": _find_text_opt(dp, "EinheitBezeichnung") or "",
@@ -258,20 +282,56 @@ async def run(username: str, password: str, *, fetch_values: bool = False) -> No
                     aid for aid, e in base_entries.items()
                     if e["readable"] and e["type"] not in ("CircuitTime",)
                 ]
-                print(f"Fetching values for {len(readable_ids)} readable attributes...")
+                print(f"Fetching values for {len(readable_ids)} readable attributes...", file=sys.stderr)
                 values = await get_data(session, cookies, loc_id, dev_id, readable_ids)
-                print(f"Got {len(values)} values\n")
+                print(f"Got {len(values)} values\n", file=sys.stderr)
 
-            # Collect unique units for summary
+            # JSON output mode
+            if output_json:
+                device_data = {
+                    "device_name": dev_name,
+                    "device_id": dev_id,
+                    "location_name": loc_name,
+                    "location_id": loc_id,
+                    "attributes": {},
+                }
+                for attr_id in sorted(base_entries):
+                    e = base_entries[attr_id]
+                    entry: dict = {
+                        "name": e["name"],
+                        "type": e["type"],
+                        "type_value": e["type_value"],
+                        "min": e["min"],
+                        "max": e["max"],
+                        "unit": e["unit"],
+                        "group": e["group"],
+                        "heating_circuit_id": e["hc_id"],
+                        "factory_default": e["default"],
+                        "readable": e["readable"],
+                        "writable": e["writable"],
+                    }
+                    if "enums" in e:
+                        entry["enum_values"] = {
+                            str(k): v for k, v in sorted(e["enums"].items())
+                        }
+                    if attr_id in values:
+                        entry["current_value"] = values[attr_id]
+                    device_data["attributes"][str(attr_id)] = entry
+                json_output.append(device_data)
+                continue
+
+            # Collect unique units and type mappings for summary
             units: set[str] = set()
+            type_mapping: dict[str, set[str]] = {}  # type_value -> {type_str, ...}
+            groups: set[str] = set()
 
             # Print table
             val_header = " Value" + " " * 15 if fetch_values else ""
             print(
-                f"{'ID':>6}  {'Name':<40} {'Type':<12} {'Unit':<8} "
-                f"{'Min':<10} {'Max':<10} {'RO/RW':<5}{val_header}"
+                f"{'ID':>6}  {'Name':<40} {'Type':<12} {'TV':>3} {'Unit':<8} "
+                f"{'Min':<10} {'Max':<10} {'RO/RW':<5} {'HC':>2} {'Group':<16} {'Default':<10}{val_header}"
             )
-            print("-" * (100 + (20 if fetch_values else 0)))
+            print("-" * (130 + (20 if fetch_values else 0)))
 
             for attr_id in sorted(base_entries):
                 e = base_entries[attr_id]
@@ -283,14 +343,18 @@ async def run(username: str, password: str, *, fetch_values: bool = False) -> No
 
                 if e["unit"]:
                     units.add(e["unit"])
+                if e["group"]:
+                    groups.add(e["group"])
+                if e["type_value"]:
+                    type_mapping.setdefault(e["type_value"], set()).add(e["type"])
 
                 val_col = ""
                 if fetch_values and attr_id in values:
                     val_col = f" {values[attr_id]}"
 
                 print(
-                    f"{e['id']:>6}  {e['name']:<40} {e['type']:<12} {e['unit']:<8} "
-                    f"{e['min']:<10} {e['max']:<10} {rw:<5}{val_col}"
+                    f"{e['id']:>6}  {e['name']:<40} {e['type']:<12} {e['type_value']:>3} {e['unit']:<8} "
+                    f"{e['min']:<10} {e['max']:<10} {rw:<5} {e['hc_id']:>2} {e['group']:<16} {e['default']:<10}{val_col}"
                 )
 
                 if "enums" in e:
@@ -301,27 +365,78 @@ async def run(username: str, password: str, *, fetch_values: bool = False) -> No
             if fetch_values:
                 print(f"Values retrieved: {len(values)}")
 
+            # Type value mapping summary
+            if type_mapping:
+                print(f"\nDatenpunktTypWert -> DatenpunktTyp mapping:")
+                for tv in sorted(type_mapping, key=lambda x: int(x) if x.isdigit() else 999):
+                    types = ", ".join(sorted(type_mapping[tv]))
+                    count = sum(
+                        1 for e in base_entries.values() if e["type_value"] == tv
+                    )
+                    print(f"  {tv:>3} -> {types} ({count} attrs)")
+
             # Unit summary
             if units:
-                print(f"\nUnique units found: {sorted(units)}")
-            else:
-                print("\nNo units returned by API (EinheitBezeichnung empty for all attributes)")
+                print(f"\nUnique units: {sorted(units)}")
+
+            # Group summary
+            if groups:
+                print(f"\nUnique groups: {sorted(groups)}")
 
             print()
 
+        # Final JSON output
+        if output_json:
+            print(json.dumps(json_output, indent=2, ensure_ascii=False))
+
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Vitotrol device discovery")
-    parser.add_argument("--user", default=os.environ.get("VITOTROL_USER"), help="Vitotrol username (or VITOTROL_USER env)")
-    parser.add_argument("--password", default=os.environ.get("VITOTROL_PASSWORD"), help="Vitotrol password (or VITOTROL_PASSWORD env)")
-    parser.add_argument("--values", action="store_true", help="Also fetch current cached values via GetData")
+    parser = argparse.ArgumentParser(
+        description="Vitotrol device discovery — scan the SOAP API for all attributes"
+    )
+    parser.add_argument(
+        "--user",
+        default=os.environ.get("VITOTROL_USER"),
+        help="Vitotrol username (or VITOTROL_USER env)",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.environ.get("VITOTROL_PASSWORD"),
+        help="Vitotrol password (or VITOTROL_PASSWORD env)",
+    )
+    parser.add_argument(
+        "--values",
+        action="store_true",
+        help="Also fetch current cached values via GetData",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output structured JSON (pipe to file with > dump.json)",
+    )
+    parser.add_argument(
+        "--raw-xml",
+        action="store_true",
+        help="Dump raw GetTypeInfo XML per device to typeinfo_<id>.xml",
+    )
     args = parser.parse_args()
 
     if not args.user or not args.password:
-        print("Error: provide --user/--password or set VITOTROL_USER/VITOTROL_PASSWORD env vars", file=sys.stderr)
+        print(
+            "Error: provide --user/--password or set VITOTROL_USER/VITOTROL_PASSWORD env vars",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
-    asyncio.run(run(args.user, args.password, fetch_values=args.values))
+    asyncio.run(
+        run(
+            args.user,
+            args.password,
+            fetch_values=args.values,
+            output_json=args.json,
+            dump_raw_xml=args.raw_xml,
+        )
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Centralized auto-routing** of unknown device attributes via `infer_unknown_metadata()` in `entity.py`, replacing scattered ad-hoc heuristics across platforms
- **German name pattern matching** for proper device classes, units, and state classes (`temp_*` → temperature/°C, `info_*leistung*` → power/W, `info_historie_eee_*` → energy/kWh, etc.)
- **Group field parsing** extracts subsystem suffix (e.g. `HC1`, `WW`) as display name prefix for unknown attrs
- **New `datetime` platform** for Date-type attributes: holiday start (306), holiday end (309), device date/time (5385)
- **Binary sensor auto-routing** for unknown Aus/Ein ENUM attributes (previously only known attrs were routed)
- **Removed dead code**: `info.unit` checks in sensor.py and number.py (API always returns empty units, confirmed via discovery script)
- **Enhanced `scripts/discover.py`**: captures `DatenpunktTypWert`, adds `--json` and `--raw-xml` output modes, type mapping summary

## Context

Scanning the real API with the discovery script revealed:
- `DatenpunktTypWert` is always 0 (useless for type discrimination)
- `EinheitBezeichnung` (unit) is always empty — all code checking `info.unit` was dead
- `DatenpunktTyp` string ("Double", "Integer", "ENUM", "Date") is the only useful type discriminator
- `DatenpunktGruppe` identifies subsystem (HC1, WW, etc.)

## Test plan

- [ ] Verify known registry attrs are unaffected (same entities, names, units as before)
- [ ] Enable a disabled unknown `temp_*` Double attr → should show as temperature sensor with °C unit and measurement graph
- [ ] Enable a disabled unknown Aus/Ein ENUM attr → should appear as binary sensor, not sensor
- [ ] Enable a Date attr (306/309/5385) → should appear as datetime entity with proper parsing
- [ ] Verify CircuitTime attrs (7191-7193) are still skipped (platform=None)
- [ ] Run `scripts/discover.py --json` and verify structured output includes `type_value` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)